### PR TITLE
Updating Analytics template to work with ZappAnalyticsPluginsSDK

### DIFF
--- a/Analytics.xctemplate/PluginClasses/___PACKAGENAME___Plugin.swift
+++ b/Analytics.xctemplate/PluginClasses/___PACKAGENAME___Plugin.swift
@@ -7,8 +7,7 @@
 //
 
 import Foundation
-import ZappPlugins
-import ApplicasterSDK
+import ZappAnalyticsPluginsSDK
 
 /**
 This Template contains protocol methods to be implemented according to your needs.

--- a/Analytics.xctemplate/Podfile
+++ b/Analytics.xctemplate/Podfile
@@ -8,6 +8,7 @@ source 'git@github.com:CocoaPods/Specs.git'
 
 target '___PACKAGENAME___' do
     pod '___PACKAGENAME___Plugin', :path => '___PACKAGENAME___.podspec'
+    pod 'ApplicasterSDK', '~> 7.2.0'
 end
 
 post_install do |installer|

--- a/Analytics.xctemplate/ViewController.swift
+++ b/Analytics.xctemplate/ViewController.swift
@@ -3,11 +3,10 @@
 //  ZappAnalyticsPluginExample-iOS
 //
 //  Created by Javier Casaudoumecq on 8/8/18.
-//  Copyright © 2018 Javier Casaudoumecq. All rights reserved.
+//  Copyright © 2018 Applicaster LTD. All rights reserved.
 //
 
 import UIKit
-import ZappPlugins
 import ApplicasterSDK
 import ___PACKAGENAME___Plugin
 

--- a/Analytics.xctemplate/___PACKAGENAME___.podspec
+++ b/Analytics.xctemplate/___PACKAGENAME___.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
     s.description      = <<-DESC
                           ___PACKAGENAME___ analytics plugin for Zapp iOS.
                          DESC
-    s.homepage         = "https://github.com/applicaster/___PACKAGENAME___"
+    s.homepage         = "___VARIABLE_giturl___"
     s.license          = 'MIT'
     s.author           = { "___FULLUSERNAME___" => "___VARIABLE_autherEmail___" }
     s.source           = { :git => "___VARIABLE_giturl___", :tag => s.version.to_s }
@@ -20,8 +20,7 @@ Pod::Spec.new do |s|
       s.resources = []
       c.frameworks = 'UIKit'
       c.source_files = 'PluginClasses/*.{swift,h,m}'
-      c.dependency 'ZappPlugins'
-      c.dependency 'ApplicasterSDK'
+      c.dependency 'ZappAnalyticsPluginsSDK'
     end
                   
     s.xcconfig =  { 'CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES' => 'YES',


### PR DESCRIPTION
## Description
Updating Analytics template to work with ZappAnalyticsPluginsSDK.
Following infrastructure changes, the Zapp Analytics Plugins protocols are now part of the ZappAnalyticsPluginsSDK and not part of ZappPlugins.

## Known issues
none.

## Checklist

* [x] PR is scoped to one task
* [ ] Tests are included
* [ ] Documentation is included

* [x] This PR is not making any UI change
* [ ] This PR is making a UI change
  * [ ] Screenshot(s) included

## QA :

* required test cases:
* specific apps / plugins to test :
