### PR TITLE
Updating the full screen template to work with ZappGeneralPluginsSDK

### DIFF
--- a/Full Screen.xctemplate/PluginClasses/Zapp___PACKAGENAME___Adapter.swift
+++ b/Full Screen.xctemplate/PluginClasses/Zapp___PACKAGENAME___Adapter.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import ZappGeneralPluginsSDK
 import ZappPlugins
 
 @objc public class Zapp___PACKAGENAME___Adapter: ZPGeneralBaseProvider, ZPAppLoadingHookProtocol {

--- a/Full Screen.xctemplate/___PACKAGENAME___.podspec
+++ b/Full Screen.xctemplate/___PACKAGENAME___.podspec
@@ -20,6 +20,7 @@ Pod::Spec.new do |s|
       s.resources = []
       c.frameworks = 'UIKit'
       c.source_files = 'PluginClasses/*.{swift,h,m}'
+      c.dependency 'ZappGeneralPluginsSDK'
       c.dependency 'ZappPlugins'
     end
                   


### PR DESCRIPTION
## Description
Updating the full-screen template to work with ZappGeneralPluginsSDK.
The `ZPGeneralBaseProvider` was moved from `ZappPlugins` to `ZappGeneralPluginsSDK` framework.
The `ZPAppLoadingHookProtocol` is still part of `ZappPlugins` (that's why it is still required to import it in plugins that want to use the loading hooks).

## Known issues

## Checklist

* [x] PR is scoped to one task
* [ ] Tests are included
* [ ] Documentation is included

* [x] This PR is not making any UI change
* [ ] This PR is making a UI change
  * [ ] Screenshot(s) included

## QA :

* required test cases:
* specific apps / plugins to test :
